### PR TITLE
Swap elt

### DIFF
--- a/code/List/Program_Playground.v
+++ b/code/List/Program_Playground.v
@@ -1,4 +1,5 @@
 Require Import Program List Psatz.
+Require Import Lists.List.
 Local Open Scope list_scope.
 
 Section Span.

--- a/code/List/Program_Playground.v
+++ b/code/List/Program_Playground.v
@@ -60,14 +60,15 @@ Lemma swap_break :
     n <> m ->
     fst (break nat (Nat.eqb n) l) = swap m n (fst (break nat (Nat.eqb m) (swap n m l))).
 Proof.
-  induction l; simpl; eauto; intros.
+  induction l; simpl; unfold swap_elt; eauto; intros.
   split_if; eauto.
   -  destruct (break nat (Nat.eqb n) l); simpl in *.
      rewrite IHl; eauto.
-     destruct (break nat (Nat.eqb a) (swap n a l)); simpl; split_if.
+     destruct (break nat (Nat.eqb a) (swap n a l)); simpl; unfold swap_elt; split_if.
   - destruct (break nat (Nat.eqb n) l); simpl.
     simpl in *; rewrite IHl; eauto.
     destruct (break nat (Nat.eqb m) (swap n m l)); simpl; split_if.
+    unfold swap_elt; split_if.
 Qed.
 
 Lemma swap_break_snd :
@@ -75,9 +76,10 @@ Lemma swap_break_snd :
     n <> m ->
     swap n m (snd (break nat (Nat.eqb n) l)) = snd (break nat (Nat.eqb m) (swap n m l)).
 Proof.
-  induction l; simpl.
+  induction l; simpl; unfold swap_elt.
   - reflexivity.
-  - intros; split_if; eauto.
+  - intros; split_if; eauto; unfold swap_elt.
+    + split_if; reflexivity.
     + destruct (break nat (Nat.eqb n) l); simpl in *.
       rewrite IHl by eauto.
       destruct (break nat (Nat.eqb a) (swap n a l)); reflexivity.
@@ -106,7 +108,7 @@ Proof.
   - destruct l; intros; try reflexivity.
     (* Is there a better way to simplify wordsBy than unfolding / rewriting / folding? *)
     unfold wordsBy at 1; simpl.
-    rewrite WfExtensionality.fix_sub_eq_ext; simpl; split_if.
+    rewrite WfExtensionality.fix_sub_eq_ext; simpl; unfold swap_elt; split_if.
     + fold (wordsBy (Nat.eqb n0) l).
       (* We also have to do this to simplify the occurence of wordsBy on the righthand side: *)
       unfold wordsBy at 2;
@@ -122,6 +124,7 @@ Proof.
       fold (wordsBy (Nat.eqb n0) (snd (break nat (Nat.eqb n0) (swap n n0 l)))).
       split_if.
       repeat f_equal.
+      * unfold swap_elt; split_if.
       * eapply swap_break; eauto.
       * rewrite IHbnd by (etransitivity; [eapply span_snd_smaller | simpl in *; lia]).
         rewrite swap_break_snd by eauto; reflexivity.
@@ -134,8 +137,9 @@ Proof.
       destruct (Nat.eqb n m) eqn: Heqb ;
         [eapply EqNat.beq_nat_true in Heqb; subst
         | eapply EqNat.beq_nat_false in Heqb].
-      * rewrite !swap_id; eauto.
-      * erewrite swap_break, swap_break_snd; eauto.
+      * rewrite swap_elt_id; rewrite !swap_id; eauto.
+      * unfold swap_elt; erewrite swap_break, swap_break_snd; eauto.
+        split_if.
   - eapply H; eauto.
 Qed.
 
@@ -156,7 +160,7 @@ Proof.
     clear l; destruct x as [ | n0 l ]; intros; try reflexivity.
     (* Is there a better way to simplify wordsBy than unfolding / rewriting / folding? *)
     unfold wordsBy at 1; simpl.
-    rewrite WfExtensionality.fix_sub_eq_ext; simpl; split_if.
+    rewrite WfExtensionality.fix_sub_eq_ext; simpl; unfold swap_elt; split_if.
     + fold (wordsBy (Nat.eqb n0) l).
       (* We also have to do this to simplify the occurence of wordsBy on the righthand side: *)
       unfold wordsBy at 2;
@@ -169,6 +173,7 @@ Proof.
       fold (wordsBy (Nat.eqb n0) (snd (break nat (Nat.eqb n0) (swap n n0 l)))).
       split_if.
       repeat f_equal.
+      * unfold swap_elt; split_if.
       * eapply swap_break; eauto.
       * (* Again, we cannot get away from needing to prove that the
          recursive application is to a 'smaller' term. *)
@@ -184,8 +189,9 @@ Proof.
       * destruct (Nat.eqb n m) eqn: Heqb ;
           [eapply EqNat.beq_nat_true in Heqb; subst
           | eapply EqNat.beq_nat_false in Heqb].
-        -- rewrite !swap_id; eauto.
+        -- rewrite swap_elt_id; rewrite !swap_id; eauto.
         -- erewrite swap_break, swap_break_snd; eauto.
+           unfold swap_elt; split_if.
       * generalize (span_snd_smaller _ (fun a : nat => negb (Nat.eqb n a)) l);
           unfold break; simpl; intros; lia.
 Qed.

--- a/code/List/Program_Playground.v
+++ b/code/List/Program_Playground.v
@@ -1,5 +1,6 @@
 Require Import Program List Psatz.
 Require Import Lists.List.
+Require Import Swap.
 Local Open Scope list_scope.
 
 Section Span.
@@ -53,47 +54,6 @@ Eval compute in (wordsBy (Nat.eqb 0) (0 :: 1 :: 1 :: 2 :: 0 :: 1 :: 3 :: 5 :: 0 
    in *proofs* as well.  We'll prove that (more or less) if we
    consistently update the element used to split a list, it won't
    effect the behavior of [wordsBy]: *)
-
-(* Lemma wordsBy_swap : forall n m l,
-    wordsBy (Nat.eqb n) l = map (swap m n) (wordsBy (Nat.eqb m) (swap n m l)).
-    Proof.  *)
-
-Fixpoint swap (n m : nat) (l : list nat) : list nat :=
-  match l with
-  | a :: l' => (if Nat.eqb n a then m
-                else if Nat.eqb m a then n
-                     else a) :: (swap n m l')
-  | _ => nil
-  end.
-
-Ltac split_if :=
-  repeat
-    match goal with
-    | |- context[Nat.eqb ?n ?n] =>
-        rewrite (PeanoNat.Nat.eqb_refl n); simpl
-    | |- context[Nat.eqb ?m ?n] =>
-        let Heqb := fresh in
-        destruct (Nat.eqb m n) eqn: Heqb; simpl;
-        [ apply EqNat.beq_nat_true in Heqb;
-          subst; simpl;
-          try congruence
-        | apply EqNat.beq_nat_false in Heqb;
-          try congruence ]
-    | H : context[Nat.eqb ?m ?n] |- _ =>
-        let Heqb := fresh in
-        destruct (Nat.eqb m n) eqn: Heqb; simpl;
-        [ apply EqNat.beq_nat_true in Heqb;
-          subst; simpl;
-          try congruence
-        | apply EqNat.beq_nat_false in Heqb;
-          try congruence ]
-  end.
-
-Lemma swap_id : forall (n : nat) (l : list nat),
-    swap n n l = l.
-Proof.
-  induction l; simpl; eauto; split_if.
-Qed.
 
 Lemma swap_break :
   forall n m l,

--- a/code/List/Span.v
+++ b/code/List/Span.v
@@ -30,6 +30,11 @@ Section Span.
        end
     }.
   
+  Lemma SpanFunctorId : FmapId SpanF SpanFunctor.
+    intros B d.
+    destruct d; trivial.
+  Qed.
+
   Definition SpanAlg(p : A -> bool)
     : Alg (ListF A) SpanF :=
     rollAlg 

--- a/code/List/Swap.v
+++ b/code/List/Swap.v
@@ -1,13 +1,12 @@
 Require Import Lists.List EqNat.
 Local Open Scope list_scope.
 
-Fixpoint swap (n m : nat) (l : list nat) : list nat :=
-  match l with
-  | a :: l' => (if Nat.eqb n a then m
-                else if Nat.eqb m a then n
-                     else a) :: (swap n m l')
-  | _ => nil
-  end.
+Definition swap_elt (n m a : nat) : nat :=
+  if Nat.eqb n a then m
+  else if Nat.eqb m a then n
+  else a.
+
+Definition swap(n m : nat) := map (swap_elt n m).
 
 Ltac split_if :=
   repeat
@@ -32,8 +31,13 @@ Ltac split_if :=
           try congruence ]
   end.
 
+Lemma swap_elt_id(n a : nat) : swap_elt n n a = a.
+  unfold swap_elt.
+  split_if.
+Qed.
+
 Lemma swap_id : forall (n : nat) (l : list nat),
     swap n n l = l.
 Proof.
-  induction l; simpl; eauto; split_if.
+  induction l; simpl; eauto; unfold swap_elt; split_if.
 Qed.

--- a/code/List/Swap.v
+++ b/code/List/Swap.v
@@ -1,0 +1,39 @@
+Require Import Lists.List EqNat.
+Local Open Scope list_scope.
+
+Fixpoint swap (n m : nat) (l : list nat) : list nat :=
+  match l with
+  | a :: l' => (if Nat.eqb n a then m
+                else if Nat.eqb m a then n
+                     else a) :: (swap n m l')
+  | _ => nil
+  end.
+
+Ltac split_if :=
+  repeat
+    match goal with
+    | |- context[Nat.eqb ?n ?n] =>
+        rewrite (PeanoNat.Nat.eqb_refl n); simpl
+    | |- context[Nat.eqb ?m ?n] =>
+        let Heqb := fresh in
+        destruct (Nat.eqb m n) eqn: Heqb; simpl;
+        [ apply EqNat.beq_nat_true in Heqb;
+          subst; simpl;
+          try congruence
+        | apply EqNat.beq_nat_false in Heqb;
+          try congruence ]
+    | H : context[Nat.eqb ?m ?n] |- _ =>
+        let Heqb := fresh in
+        destruct (Nat.eqb m n) eqn: Heqb; simpl;
+        [ apply EqNat.beq_nat_true in Heqb;
+          subst; simpl;
+          try congruence
+        | apply EqNat.beq_nat_false in Heqb;
+          try congruence ]
+  end.
+
+Lemma swap_id : forall (n : nat) (l : list nat),
+    swap n n l = l.
+Proof.
+  induction l; simpl; eauto; split_if.
+Qed.

--- a/code/_CoqProject
+++ b/code/_CoqProject
@@ -23,6 +23,7 @@ List/SplitAt.v
 List/WordsBy.v
 List/WordsByWf.v
 List/WordsByPath.v
+List/Swap.v
 List/ChunksOf.v
 List/Rle.v
 List/RleSingleRec.v


### PR DESCRIPTION
I refactored swap into swap_elt and map, hoping that it would help me as I try to redo swap_break for our version of break.  I am struggling with the latter, due to trouble controlling unfolding of our definitions.  The cost of the refactoring for Program_Playground is that now swap_elt has to get unfolded some places.  Maybe there is a better way to have that happen?